### PR TITLE
Add agile plan canvas document

### DIFF
--- a/agile-plan-canvas.md
+++ b/agile-plan-canvas.md
@@ -1,0 +1,42 @@
+# Agile Plan Canvas
+
+## Overview
+This document provides a high-level agile plan for building the Commercial Value Architecture visualization tool. It outlines the major tasks required to deliver an interactive diamond representing organizational force fields.
+
+## Task List
+1. **Project Setup**
+   - Initialize React project structure
+   - Configure Tailwind CSS and development tools
+2. **Core Components**
+   - Create `CommercialValueArchitecture` container
+   - Implement `DiamondVisualization` SVG component
+   - Build `BalanceControls` for sliders
+   - Add `ExecutiveContext` information panel
+3. **State Management**
+   - Set up React state hooks for balance points
+   - Implement context or hooks for shared state
+4. **Calculations & Logic**
+   - Implement diamond geometry calculations
+   - Develop structural integrity scoring function
+   - Map slider positions to effect descriptions
+5. **User Interaction**
+   - Wire sliders to update diamond in real time
+   - Add "Ideal Form" reset functionality
+   - Add "Stress Test" randomization feature
+6. **Styling & UX**
+   - Apply Tailwind styles for layout and accessibility
+   - Ensure responsive design across devices
+   - Add color cues for structural integrity ranges
+7. **Testing & QA**
+   - Write unit tests for calculation utilities
+   - Implement component-level tests for interactions
+   - Perform manual testing for usability issues
+8. **Documentation**
+   - Document architecture and component responsibilities
+   - Provide usage guide and interpretation notes
+9. **Future Enhancements**
+   - Plan additional visualization layers
+   - Outline export and historical tracking features
+
+## Notes
+This canvas serves as a starting point for planning sprints and prioritizing work. Tasks can be broken down further during sprint planning.


### PR DESCRIPTION
## Summary
- add Agile Plan Canvas documenting major tasks for the Commercial Value Architecture tool

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935c5b139c8320ba0b101b61c8c5fe